### PR TITLE
Fix CI workflow to target 'main' instead of 'master'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
       - release-*
   pull_request:
   workflow_dispatch:


### PR DESCRIPTION
While doing a release for AmazonSQS, there is a line that prompts to check on this repo for a PR: 

> Validate the new version of the transport package doesn't break [CloudEvents](https://github.com/Particular/NServiceBus.Envelope.CloudEvents) support

The Renovate PR was here, but after I merged it, the CI for the main branch wasn't triggered.